### PR TITLE
update publish workflow to use auto generated GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Publish
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
 		"type": "git",
 		"url": "https://github.com/excalibur-enterprise/timeval-js.git"
 	},
-	"publishConfig": {
-		"registry":"https://npm.pkg.github.com"
-	},
 	"bugs": {
 		"url": "https://github.com/excalibur-enterprise/timeval-js/issues"
 	},

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
 		"type": "git",
 		"url": "https://github.com/excalibur-enterprise/timeval-js.git"
 	},
+	"publishConfig": {
+		"registry":"https://npm.pkg.github.com"
+	},
 	"bugs": {
 		"url": "https://github.com/excalibur-enterprise/timeval-js/issues"
 	},


### PR DESCRIPTION
GITHUB_TOKEN permissions are calculated based on the definition in `jobs.publish.permissions`